### PR TITLE
IDA权威指南→IDA Pro权威指南

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@
 
 · 《C++反汇编与逆向分析技术揭秘》钱林松；赵海旭
 
-· 《IDA权威指南》【美】Chris Eagle
+· 《IDA Pro权威指南》【美】Chris Eagle
 
 · 《逆向工程权威指南》【乌克兰】Dennis Yurichev，多平台入门大全
 


### PR DESCRIPTION
这本书应该是叫《IDA Pro权威指南》
参考[全国图书馆参考咨询联盟](http://book.ucdrs.superlib.net/views/specific/2929/bookDetail.jsp?dxNumber=000008229556&d=36EB5A99C0BC76197C0E1A81E6289CF2&fenlei=1817040303)